### PR TITLE
Add .gitignore and remove .vscode from tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# IDE and Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Temporary files
+*.tmp
+*.temp

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "workbench.colorTheme": "Default Dark Modern",
-    "workbench.startupEditor": "none"
-}


### PR DESCRIPTION
## Changes

This PR adds a comprehensive `.gitignore` file and removes the `.vscode` directory from git tracking.

### What's included:

- **`.gitignore`** file that covers:
  - IDE and editor files (`.vscode/`, `.idea/`, vim swap files)
  - OS-generated files (`.DS_Store`, `Thumbs.db`, etc.)
  - Temporary files (`*.tmp`, `*.temp`)

- **Removed `.vscode/settings.json`** from git tracking to avoid committing editor-specific settings

### Why this change:

- Prevents IDE/editor-specific configuration files from being committed
- Keeps the repository clean by ignoring OS-generated and temporary files
- Follows best practices for repository hygiene

This is a standard housekeeping change that will help maintain a cleaner repository going forward.